### PR TITLE
Release version 0.6 with updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sid"
-version = "0.5.2"
+version = "0.6.0"
 description = "Simple Id. Tiny crate providing strongly typed ids and an id-based vector."
 license = "MIT/Apache-2.0"
 authors = [ "Nicolas Silva <nical@fastmail.com>" ]
@@ -10,4 +10,4 @@ repository = "https://github.com/nical/sid"
 name = "sid"
 
 [dependencies]
-num-traits = "0.1.39"
+num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # sid
+
+[![Crates.io](https://img.shields.io/crates/v/sid.svg)](https://crates.io/crates/sid)
+[![Docs](https://docs.rs/sid/badge.svg)](https://docs.rs/sid)
+
 Tiny rust crate providing strongly typed id types and an id-based vector.


### PR DESCRIPTION
Updating num_traits is a breaking change because the types are exposed.

Also threw in some repo niceties: `.gitignore` and readme badges